### PR TITLE
Add embeddable media-tag-nacl.js which allows for loading media remotely

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,8 @@
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "requirejs": "^2.3.3",
+    "tweetnacl": "^1.0.0",
+    "tweetnacl-util": "^0.15.0",
     "yarn": "^0.21.3"
   },
   "babel": {

--- a/src/presets/media-tag-nacl.js
+++ b/src/presets/media-tag-nacl.js
@@ -1,0 +1,3 @@
+window.nacl = require('tweetnacl');
+window.nacl.util = require('tweetnacl-util');
+module.exports = require('./media-tag');

--- a/webpack.config/media-tag.webpack.config.dev.js
+++ b/webpack.config/media-tag.webpack.config.dev.js
@@ -21,6 +21,7 @@ const pluginList = [
 module.exports = function () {
 	return {
 		entry: {
+			'media-tag-nacl': './src/presets/media-tag-nacl.js',
 			'media-tag': './src/presets/media-tag.js',
 			'media-tag-react': './src/presets/media-tag.react.js',
 			'media-tag-core': './src/core/media-tag-api.js',

--- a/webpack.config/media-tag.webpack.config.pro.js
+++ b/webpack.config/media-tag.webpack.config.pro.js
@@ -22,6 +22,7 @@ const pluginList = [
 module.exports = function () {
 	return {
 		entry: {
+			'media-tag-nacl': './src/presets/media-tag-nacl.js',
 			'media-tag': './src/presets/media-tag.js',
 			'media-tag-react': './src/presets/media-tag.react.js',
 			'media-tag-core': './src/core/media-tag-api.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6502,9 +6502,17 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+tweetnacl-util@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.0.tgz#4576c1cee5e2d63d207fee52f1ba02819480bc75"
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+
+tweetnacl@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.0.tgz#713d8b818da42068740bf68386d0479e66fc8a7b"
 
 type-check@~0.3.2:
   version "0.3.2"


### PR DESCRIPTION
This PR does basically 3 things:
1. Add dependencies on nacl and nacl-util so that they are available for making a bundled version
2. Change cryptpad.js to make it call a particular function on the window rather than firing a "decrypted" event. If this function doesn't exist, it will continue without waiting.
3. Create a new disturbution called `media-tag-nacl.min.js` which allows embedding in websites which do not already have nacl.